### PR TITLE
#1 Fix: 스크롤 길어질 때 하단바 안 보이는 버그 수정

### DIFF
--- a/src/components/layout/AppShell.tsx
+++ b/src/components/layout/AppShell.tsx
@@ -8,17 +8,29 @@ export default function AppShell({ children }: { children: React.ReactNode }) {
   const pathname = usePathname();
 
   return (
-    // 화면 전체: 가운데에 모바일 프레임을 놓고, safe-area 패딩을 준다
-    <div className="min-h-dvh flex justify-center bg-stone-50 p-safe">
-      {/* 모바일 프레임 박스 */}
+    // 화면 전체를 고정: 바깥은 스크롤 안 됨
+    <div className="fixed inset-0 flex justify-center bg-stone-50 p-safe overflow-hidden">
+      {/* 모바일 프레임: 뷰포트 높이에 딱 맞춤 */}
       <div
-        className="w-full max-w-[var(--app-max-w)] bg-white border border-stone-200
-                   rounded-2xl shadow-sm flex flex-col overflow-hidden"
+        className="
+          flex h-dvh w-full max-w-[var(--app-max-w)] flex-col
+          overflow-hidden rounded-2xl border border-stone-200 bg-white shadow-sm
+        "
       >
-        <Header />
+        {/* (선택) 상단 고정하고 싶으면 sticky */}
+        <div className="sticky top-0 z-10 bg-white">
+          <Header />
+        </div>
+
         {/* 본문만 스크롤 */}
-        <main className="flex-1 overflow-y-auto">{children}</main>
-        <BottomBar />
+        <main className="flex-1 min-h-0 overflow-y-auto overscroll-contain">
+          {children}
+        </main>
+
+        {/* (선택) 하단을 더 확실히 고정하고 싶으면 sticky */}
+        <div className="sticky bottom-0 z-10 bg-white">
+          <BottomBar />
+        </div>
       </div>
     </div>
   );


### PR DESCRIPTION
## #️⃣ Issue Number
#1 

## 📝 요약(Summary)
스크롤이 길어지면 하단바가 그 길어진 내용 밑에 붙어서 스크롤을 해야 하단바가 보이는 문제가 있었습니다.
이제 하단바를 고정해두고 내용이 길어져도 하단바가 보인 채 스크롤을 할 수 있습니다.

## 🛠️ PR 유형

어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 📸스크린샷 (선택)

## 💬 공유사항 to 리뷰어

<!--- 리뷰어가 중점적으로 봐줬으면 좋겠는 부분이 있으면 적어주세요. -->
<!--- 논의해야할 부분이 있다면 적어주세요.-->
<!--- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->
