### PR TITLE
Fix: 회원가입 완료 후 축하 화면에 회원가입한 닉네임으로 뜨게

### DIFF
--- a/src/containers/user/LoginContainer.tsx
+++ b/src/containers/user/LoginContainer.tsx
@@ -72,7 +72,7 @@ export default function LoginFlow() {
         } else if (err.status === 500) {
           setError("서버에서 오류가 발생했습니다. 잠시 후 다시 시도해주세요.")
         } else if (err.status === 0) {
-          setError("서버에 연결할 수 없습니다. 서버가 실행 중인지 확인해주세요.")
+          setError("서버에 연결할 수 없습니다.")
         } else {
           setError(err.message)
         }

--- a/src/containers/user/SignupContainer.tsx
+++ b/src/containers/user/SignupContainer.tsx
@@ -8,7 +8,7 @@ import { signup } from "@/utils/api"
 import { SignupRequest } from "@/types/api/auth"
 
 interface SignupContainerProps {
-  onSignupComplete: () => void
+  onSignupComplete: (nickname: string) => void
 }
 
 export default function SignupContainer({ onSignupComplete }: SignupContainerProps) {
@@ -68,8 +68,8 @@ export default function SignupContainer({ onSignupComplete }: SignupContainerPro
 
       await signup(signupData)
       
-      // 회원가입 성공
-      onSignupComplete()
+      // 회원가입 성공 - 닉네임 전달
+      onSignupComplete(formData.nickname)
     } catch (err: any) {
       console.error("Signup error:", err)
       setError(err.message || "회원가입에 실패했습니다. 다시 시도해주세요.")

--- a/src/containers/user/SignupFlow.tsx
+++ b/src/containers/user/SignupFlow.tsx
@@ -8,8 +8,10 @@ import WelcomeContainer from "./WelcomeContainer"
 export default function SignupFlow() {
   const router = useRouter()
   const [currentStep, setCurrentStep] = useState<"signup" | "welcome">("signup")
+  const [userNickname, setUserNickname] = useState<string>("")
 
-  const handleSignupComplete = () => {
+  const handleSignupComplete = (nickname: string) => {
+    setUserNickname(nickname)
     setCurrentStep("welcome")
   }
 
@@ -22,7 +24,7 @@ export default function SignupFlow() {
   }
 
   if (currentStep === "welcome") {
-    return <WelcomeContainer onComplete={handleWelcomeComplete} />
+    return <WelcomeContainer onComplete={handleWelcomeComplete} nickname={userNickname} />
   }
 
   return null

--- a/src/containers/user/WelcomeContainer.tsx
+++ b/src/containers/user/WelcomeContainer.tsx
@@ -7,9 +7,10 @@ import MainButton from "@/components/common/MainButton"
 
 interface WelcomeContainerProps {
   onComplete: () => void
+  nickname: string
 }
 
-export default function WelcomeContainer({ onComplete }: WelcomeContainerProps) {
+export default function WelcomeContainer({ onComplete, nickname }: WelcomeContainerProps) {
   const [windowDimensions, setWindowDimensions] = useState({ width: 0, height: 0 })
 
   useEffect(() => {
@@ -76,7 +77,7 @@ export default function WelcomeContainer({ onComplete }: WelcomeContainerProps) 
         {/* Welcome Message */}
         <div className="text-center mb-20">
           <h1 className="text-4xl font-extrabold mb-8 leading-tight" style={{ color: '#6592FD' }}>
-            지구님
+            {nickname}님
             <br />
             환영합니다
           </h1>

--- a/src/utils/api.ts
+++ b/src/utils/api.ts
@@ -73,7 +73,7 @@ async function apiCall<T>(
   } catch (error) {
     if (error instanceof TypeError && error.message === 'Failed to fetch') {
       throw {
-        message: '서버에 연결할 수 없습니다. 서버가 실행 중인지 확인해주세요.',
+        message: '서버에 연결할 수 없습니다.',
         status: 0,
       } as ApiError
     }


### PR DESCRIPTION
## #️⃣ Issue Number
#36 

## 📝 요약(Summary)
회원가입 했을 때 나오는 축하화면에서 사용자가 회원가입했을 때 입력한 닉네임으로 뜨게 설정했습니다.

## 🛠️ PR 유형

어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 📸스크린샷 (선택)

## 💬 공유사항 to 리뷰어

<!--- 리뷰어가 중점적으로 봐줬으면 좋겠는 부분이 있으면 적어주세요. -->
<!--- 논의해야할 부분이 있다면 적어주세요.-->
<!--- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->
